### PR TITLE
Merge pull request #135 from 1Money-Co/fix/InputAmount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ es
 umd
 dist*
 
+.env
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 *~
 ~*
 
+.env
 .github
 .vscode
 .cursor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1money/react-ui",
-  "version": "1.7.20",
+  "version": "1.7.21",
   "description": "React Components based on primereact for 1money front-end projects",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/InputAmount/InputAmount.tsx
+++ b/src/components/InputAmount/InputAmount.tsx
@@ -57,7 +57,7 @@ export const InputAmount: FC<PropsWithChildren<InputAmountProps>> = props => {
     if (!input) return;
     const len = input.value?.length;
     const position = input.scrollLeft;
-    const shouldToEnd = !!position || !sticky;
+    const shouldToEnd = !sticky;
     const start = shouldToEnd ? len : inputCaretPositionRef.current;
     input.setSelectionRange(start, start);
     input.scrollLeft = shouldToEnd ? input.scrollWidth : position;


### PR DESCRIPTION
fix: InputAmount will auto to end when user Input length exceed 100% of is parent node width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input field behavior by simplifying caret and scroll position logic for a more consistent user experience.

* **Chores**
  * Updated internal configuration to ignore environment files in version control and npm packages.
  * Bumped package version to 1.7.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->