### PR TITLE
fix: custom scrollbar margin & table style (#137)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1money/react-ui",
-  "version": "1.7.21",
+  "version": "1.7.22",
   "description": "React Components based on primereact for 1money front-end projects",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/Dropdown/style/Dropdown.scss
+++ b/src/components/Dropdown/style/Dropdown.scss
@@ -25,7 +25,8 @@ $cls: #{$prefix}-#{$component};
     border: none;
     border-radius: 0;
 
-    &, * {
+    &,
+    * {
       &::-webkit-scrollbar {
         width: 2px;
       }
@@ -33,8 +34,16 @@ $cls: #{$prefix}-#{$component};
       &::-webkit-scrollbar-thumb {
         max-width: 100%;
         max-height: 100%;
-        background-color: $color-grey-dark;
+        background-color: transparent;
         border-radius: 2px;
+      }
+
+      &::-webkit-scrollbar-track {
+        margin: 2px 0;
+      }
+
+      &:hover::-webkit-scrollbar-thumb {
+        background-color: $color-grey-dark;
       }
     }
   }

--- a/src/components/Select/style/Select.scss
+++ b/src/components/Select/style/Select.scss
@@ -163,8 +163,16 @@ $cls: #{$prefix}-#{$component};
     }
 
     ::-webkit-scrollbar-thumb {
-      background-color: $color-grey-dark;
+      background-color: transparent;
       border-radius: 2px;
+    }
+
+    ::-webkit-scrollbar-track {
+      margin: 2px 0;
+    }
+
+    :hover::-webkit-scrollbar-thumb {
+      background-color: $color-grey-dark;
     }
 
     &.p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight.p-focus,

--- a/src/components/Table/style/Table.scss
+++ b/src/components/Table/style/Table.scss
@@ -12,6 +12,7 @@ $component: 'table';
 
   &.p-datatable-scrollable {
     .p-datatable-wrapper {
+      z-index: 2;
       padding-right: 6px;
       overflow-x: visible !important;
     }
@@ -21,7 +22,6 @@ $component: 'table';
         background-color: $color-grey-light;
       }
     }
-
 
     &::after {
       position: absolute;
@@ -39,6 +39,18 @@ $component: 'table';
     }
   }
 
+  &:not(.#{$prefix}-#{$component}-transparent).p-datatable-scrollable {
+    .p-datatable-table {
+      .p-datatable-thead {
+        tr {
+          th {
+            border-bottom: none;
+          }
+        }
+      }
+    }
+  }
+
   .p-datatable-wrapper {
     padding: 0 8px 0 0;
 
@@ -47,8 +59,17 @@ $component: 'table';
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: $color-grey-bold;
+      background-color: transparent;
       border-radius: 4px;
+      transition: background-color 0.3s ease;
+    }
+
+    &::-webkit-scrollbar-track {
+      margin: 36px 0 4px;
+    }
+
+    &:hover::-webkit-scrollbar-thumb {
+      background-color: $color-grey-bold;
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrollbar appearance in dropdowns, select menus, and tables: scrollbars are now transparent by default and become visible with a dark grey color on hover.
  * Added smoother transitions for scrollbar thumb color changes and introduced vertical margins to scrollbar tracks.
  * Improved table header styling by removing bottom borders in certain cases and adjusted layering for scrollable tables.

* **Chores**
  * Incremented package version to 1.7.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->