### PR TITLE
fix(Sidebar): prevent menu label text truncation in SimplySidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1money/react-ui",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "React Components based on primereact for 1money front-end projects",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -144,17 +144,17 @@ export const SimplySidebar: StoryObj<typeof SimplySidebarComponent> = {
         children: [
           {
             key: 'terms-conditions',
-            label: 'Terms and Conditions',
+            label: 'Terms and Conditions Conditions Conditions',
             defaultOpen: true,
             children: [
               {
                 key: '1money-usa-customers',
-                label: '1Money USA, Inc Customers',
+                label: 'Commercial Agreement',
                 active: true,
               },
               {
                 key: '1money-bermuda-customers',
-                label: '1Money Bermuda Ltd Customers',
+                label: 'Retail Agreement',
               },
               {
                 key: 'customer-onboarding',
@@ -181,7 +181,7 @@ export const SimplySidebar: StoryObj<typeof SimplySidebarComponent> = {
           },
           {
             key: 'developer-terms',
-            label: 'Developer Terms of Service',
+            label: 'Developer Terms of Service Service Service',
           }
         ]
       }

--- a/src/components/Sidebar/style/SimplySidebar.scss
+++ b/src/components/Sidebar/style/SimplySidebar.scss
@@ -88,6 +88,12 @@ $cls: #{$prefix}-#{$component};
             color: $color-primary;
           }
 
+          .ps-menu-label {
+            overflow: visible;
+            white-space: normal;
+            text-overflow: unset;
+          }
+
           .ps-menu-icon {
             display: inline-flex;
             align-items: center;


### PR DESCRIPTION
Override react-pro-sidebar default .ps-menu-label styles to allow text wrapping instead of truncating with ellipsis. Update story examples with revised label text.

## What
<!-- Brief description of what this PR does -->

## Type
- [ ] feat - New component or enhancement
- [ ] fix - Bug fix
- [ ] refactor - Code refactoring
- [ ] style - Styling updates
- [ ] docs - Documentation updates
- [ ] chore - Dependencies, build, or tooling changes

## Components Changed
<!-- e.g., Button, Input, Table -->
-

## Breaking Changes
- [ ] No breaking changes
- [ ] Has breaking changes (describe below)

<!-- If breaking, describe what changed and migration steps -->

## Testing
- [ ] Storybook stories updated/added
- [ ] Snapshots updated (if needed)
- [ ] `pnpm lint` passed
- [ ] `pnpm build` successful
- [ ] Tested in Storybook

## Screenshots/Demo
<!-- Add before/after screenshots or Storybook link if applicable -->

## Related Issues
<!-- Closes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar menu items now properly display multi-line labels with improved text wrapping.

* **Chores**
  * Version bump to 1.17.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->